### PR TITLE
Allow FwdLaplArray as input to wrapped functions

### DIFF
--- a/folx/__init__.py
+++ b/folx/__init__.py
@@ -1,3 +1,4 @@
+import importlib.metadata
 from .interpreter import forward_laplacian
 from .operators import (
     ForwardLaplacianOperator,
@@ -22,3 +23,5 @@ __all__ = [
     'deregister_function',
     'register_function',
 ]
+
+__version__ = importlib.metadata.version(__package__ or __name__)

--- a/folx/ad.py
+++ b/folx/ad.py
@@ -1,0 +1,104 @@
+import jax
+import jax.numpy as jnp
+import jax.flatten_util as jfu
+import jax.tree_util as jtu
+
+
+def is_tree_complex(tree):
+    leaves = jtu.tree_leaves(tree)
+    return any(jnp.iscomplexobj(leaf) for leaf in leaves)
+
+
+def vjp_rc(fun, *primals: jax.Array):
+    def real_fun(*primals):
+        return jnp.real(fun(*primals))
+
+    def imag_fun(*primals):
+        return jnp.imag(fun(*primals))
+
+    _, vjp_r = jax.vjp(real_fun, *primals)
+    _, vjp_i = jax.vjp(imag_fun, *primals)
+
+    def vjp(*tangents: jax.Array):
+        real_tangents = jtu.tree_map(jnp.real, tangents)
+        imag_tangents = jtu.tree_map(jnp.imag, tangents)
+
+        # letters: v=vector, j=jacobian, r=real, i=imag
+        vr_jr = vjp_r(*real_tangents)
+        vi_jr = vjp_r(*imag_tangents)
+        vr_ji = vjp_i(*real_tangents)
+        vi_ji = vjp_i(*imag_tangents)
+
+        result = jtu.tree_map(
+            lambda vr_jr, vi_jr, vr_ji, vi_ji: vr_jr - vi_ji + 1j * (vr_ji + vi_jr),
+            vr_jr,
+            vi_jr,
+            vr_ji,
+            vi_ji,
+        )
+        return result
+
+    return vjp
+
+
+def vjp(fun, *primals: jax.Array):
+    out, vjp = jax.vjp(fun, *primals)
+    if is_tree_complex(primals):
+        if is_tree_complex(out):
+            # C -> C
+            return vjp
+        else:
+            # C -> R
+            return vjp
+    else:
+        if is_tree_complex(out):
+            # R -> C
+            return vjp_rc(fun, *primals)
+        else:
+            # R -> R
+            return vjp
+
+
+def jacrev(f):
+    # Similar to jax.jacrev but works with complex inputs and outputs.
+    # A crucial difference is that we do not preserve the structure of the output but
+    # always flatten it to a 1D array.
+    def jacfun(*primals):
+        flat_primals, unravel = jfu.ravel_pytree(primals)
+
+        def flat_f(x):
+            return jfu.ravel_pytree(f(*unravel(x)))[0]
+
+        out = flat_f(flat_primals)
+
+        result = jax.vmap(vjp(flat_f, flat_primals))(
+            jnp.eye(out.size, dtype=out.dtype)
+        )[0]
+        result = jax.vmap(unravel, out_axes=0)(result)
+        if len(primals) == 1:
+            return result[0]
+        return result
+
+    return jacfun
+
+
+def jacfwd(f):
+    # Similar to jax.jacfwd but works with complex inputs and outputs.
+    # A crucial difference is that we do not preserve the structure of the input but
+    # always flatten it to a 1D array.
+    def jacfun(*primals):
+        flat_primals, unravel = jfu.ravel_pytree(primals)
+
+        def jvp_fun(s):
+            return jax.jvp(f, primals, unravel(s))[1]
+
+        eye = jnp.eye(flat_primals.size, dtype=flat_primals.dtype)
+        J = jax.vmap(jvp_fun, out_axes=-1)(eye)
+        return J
+
+    return jacfun
+
+
+def hessian(f):
+    # Similar to jax.hessian but works with complex inputs and outputs.
+    return jacfwd(jacrev(f))

--- a/folx/api.py
+++ b/folx/api.py
@@ -225,6 +225,14 @@ class FwdJacobian(NamedTuple):
     def astype(self, dtype):
         return FwdJacobian(self.data.astype(dtype), self.x0_idx)
 
+    @property
+    def real(self):
+        return FwdJacobian(self.data.real, self.x0_idx)
+
+    @property
+    def imag(self):
+        return FwdJacobian(self.data.imag, self.x0_idx)
+
 
 class FwdLaplArray(NamedTuple):
     """
@@ -279,6 +287,14 @@ class FwdLaplArray(NamedTuple):
             )
         # If we convert to integer or boolean we drop the derivatives
         return self.x.astype(dtype)
+
+    @property
+    def real(self):
+        return FwdLaplArray(self.x.real, self.jacobian.real, self.laplacian.real)
+
+    @property
+    def imag(self):
+        return FwdLaplArray(self.x.imag, self.jacobian.imag, self.laplacian.imag)
 
 
 def IS_LPL_ARR(x):

--- a/folx/api.py
+++ b/folx/api.py
@@ -273,12 +273,8 @@ class FwdLaplArray(NamedTuple):
         return FwdLaplArray(self.x, self.jacobian.as_dense, self.laplacian)
 
     def astype(self, dtype):
-        if dtype in (
-            jnp.float16,
-            jnp.float32,
-            jnp.float64,
-            jnp.complex64,
-            jnp.complex128,
+        if jax.dtypes.issubdtype(dtype, jnp.floating) or jax.dtypes.issubdtype(
+            dtype, jnp.complexfloating
         ):
             return FwdLaplArray(
                 self.x.astype(dtype),
@@ -287,6 +283,10 @@ class FwdLaplArray(NamedTuple):
             )
         # If we convert to integer or boolean we drop the derivatives
         return self.x.astype(dtype)
+
+    @property
+    def dtype(self):
+        return self.x.dtype
 
     @property
     def real(self):

--- a/folx/jvp.py
+++ b/folx/jvp.py
@@ -373,7 +373,10 @@ def dense_elementwise_jvp(
     if y.shape != laplace_args.x[0].shape:
         return dense_split_jvp(fwd, laplace_args)
 
-    jac = jax.grad(lambda x: jnp.sum(fwd(x)))(laplace_args.x[0])  # type: ignore
+    if laplace_args.x[0].dtype in (jnp.complex64, jnp.complex128):
+        _, jac = jax.jvp(fwd, (laplace_args.x[0],), (jnp.ones_like(laplace_args.x[0]),))
+    else:
+        jac = jax.grad(lambda x: jnp.sum(fwd(x)))(laplace_args.x[0])  # type: ignore
     grad_y = jac * laplace_args.dense_jacobian[0]
     lapl_y = jac * laplace_args.laplacian[0]
     return y, grad_y, lapl_y

--- a/folx/jvp.py
+++ b/folx/jvp.py
@@ -29,6 +29,7 @@ from .utils import (
     get_jacobian_for_reduction,
     np_concatenate_brdcast,
 )
+from .ad import vjp
 
 R = TypeVar('R', bound=PyTree[Array])
 
@@ -373,10 +374,7 @@ def dense_elementwise_jvp(
     if y.shape != laplace_args.x[0].shape:
         return dense_split_jvp(fwd, laplace_args)
 
-    if laplace_args.x[0].dtype in (jnp.complex64, jnp.complex128):
-        _, jac = jax.jvp(fwd, (laplace_args.x[0],), (jnp.ones_like(laplace_args.x[0]),))
-    else:
-        jac = jax.grad(lambda x: jnp.sum(fwd(x)))(laplace_args.x[0])  # type: ignore
+    jac = vjp(fwd, laplace_args.x[0])(jnp.ones_like(y))[0]
     grad_y = jac * laplace_args.dense_jacobian[0]
     lapl_y = jac * laplace_args.laplacian[0]
     return y, grad_y, lapl_y

--- a/folx/wrapped_functions.py
+++ b/folx/wrapped_functions.py
@@ -119,7 +119,10 @@ def dtype_conversion(
 def slogdet(x):
     # We only need this custom slog det to avoid a jax bug
     # https://github.com/google/jax/issues/17379
-    return jnp.linalg.slogdet(x)
+    # We explictily decompose this here as newer version will return
+    # SlogDetResult which is a NamedTuple and does not combine nicely with regular tuples.
+    sign, logdet = jnp.linalg.slogdet(x)
+    return sign, logdet
 
 
 def slogdet_jvp(primals, tangents):

--- a/folx/wrapped_functions.py
+++ b/folx/wrapped_functions.py
@@ -163,7 +163,7 @@ def slogdet_wrapper(
     )
     sign, logdet = fwd_lapl_fn(x, {}, sparsity_threshold=0)
     # Remove the jacobian of the sign
-    if sign.x.dtype not in (jnp.complex64, jnp.complex128):
+    if jax.dtypes.issubdtype(sign.dtype, jnp.complexfloating):
         sign = sign.x
     return sign, logdet
 

--- a/folx/wrapped_functions.py
+++ b/folx/wrapped_functions.py
@@ -6,7 +6,6 @@ import jax
 import jax.numpy as jnp
 import jax.tree_util as jtu
 from jax.core import Primitive
-from jax.typing import DTypeLike
 
 from .api import (
     Array,
@@ -109,13 +108,11 @@ def dot_general(
 
 
 def dtype_conversion(
-    arr: ArrayOrFwdLaplArray,
-    *_: ArrayOrFwdLaplArray,
-    new_dtype: DTypeLike,
+    args: tuple[ArrayOrFwdLaplArray],
+    kwargs: dict[str, Any],
     sparsity_threshold: int,
-    **kwargs,
 ):
-    return arr.astype(new_dtype)
+    return args[0].astype(kwargs['new_dtype'])
 
 
 @jax.custom_jvp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'folx'
-version = '0.2.3'
+version = '0.2.4'
 description = 'Forward Laplacian for JAX'
 authors = [
     "Nicholas Gao <n.gao@tum.de>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'folx'
-version = '0.2.2'
+version = '0.2.3'
 description = 'Forward Laplacian for JAX'
 authors = [
     "Nicholas Gao <n.gao@tum.de>",

--- a/test/laplacian_testcase.py
+++ b/test/laplacian_testcase.py
@@ -1,0 +1,33 @@
+import unittest
+
+import jax
+import jax.flatten_util as jfu
+import jax.numpy as jnp
+import numpy as np
+
+
+class LaplacianTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        jax.config.update('jax_enable_x64', True)
+        return super().setUp()
+
+    def assert_allclose(self, x, y):
+        return np.testing.assert_allclose(x, y)
+
+    @staticmethod
+    def jacobian(f, x):
+        # We use forward diff here to support complex functions
+        return jax.jit(jax.jacfwd(f))(x)
+
+    @staticmethod
+    def laplacian(f, x):
+        flat_x, unravel = jfu.ravel_pytree(x)
+
+        def flat_f(flat_x):
+            return jfu.ravel_pytree(f(unravel(flat_x)))[0]
+
+        def lapl_fn(x):
+            # We use forward on forward here to support complex functions
+            return jnp.trace(jax.jacfwd(jax.jacfwd(flat_f))(x), axis1=-2, axis2=-1)
+
+        return jax.jit(lapl_fn)(flat_x)

--- a/test/test_ad.py
+++ b/test/test_ad.py
@@ -1,0 +1,41 @@
+import unittest
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from folx.ad import jacfwd, jacrev, hessian
+
+from laplacian_testcase import LaplacianTestCase
+
+
+class TestAutoDiff(LaplacianTestCase):
+    def test_jacfwd(self):
+        def f(x):
+            return jnp.sin(x * x.sum())
+
+        x = np.random.normal(size=(3, 4))
+        target_shape = (*x.shape, x.size)
+        self.assertEqual(jacfwd(f)(x).shape, target_shape)
+        self.assert_allclose(jacfwd(f)(x), jax.jacfwd(f)(x).reshape(target_shape))
+
+    def test_jacrev(self):
+        def f(x):
+            return jnp.sin(x * x.sum())
+
+        x = np.random.normal(size=(3, 4))
+        target_shape = (x.size, *x.shape)
+        self.assertEqual(jacrev(f)(x).shape, target_shape)
+        self.assert_allclose(jacrev(f)(x), jax.jacrev(f)(x).reshape(target_shape))
+
+    def test_hessian(self):
+        def f(x):
+            return jnp.sin(x * x.sum())
+
+        x = np.random.normal(size=(12))
+        target_shape = (x.size, x.size, x.size)
+        self.assertEqual(hessian(f)(x).shape, target_shape)
+        self.assert_allclose(hessian(f)(x), jax.hessian(f)(x))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_complex.py
+++ b/test/test_complex.py
@@ -1,0 +1,48 @@
+import unittest
+
+import jax
+import jax.experimental
+import jax.flatten_util as jfu
+import jax.numpy as jnp
+import numpy as np
+
+from folx import forward_laplacian
+
+jax.config.update('jax_enable_x64', True)
+
+
+def jacobian(f, x):
+    return jax.jit(jax.jacobian(f))(x)
+
+
+def laplacian(f, x):
+    flat_x, unravel = jfu.ravel_pytree(x)
+
+    def flat_f(flat_x):
+        return jfu.ravel_pytree(f(unravel(flat_x)))[0]
+
+    def lapl_fn(x):
+        return jnp.trace(jax.hessian(flat_f)(x), axis1=-2, axis2=-1)
+
+    return jax.jit(lapl_fn)(flat_x)
+
+
+class TestComplexFwdLapl(unittest.TestCase):
+    def test_imag(self):
+        x = np.random.randn(10)
+        W1 = np.random.randn(10, 10)
+        W2 = np.random.randn(10, 10)
+
+        def f(x):
+            return x @ W1 + 1j * x @ W2
+
+        for g in [jnp.real, jnp.imag]:
+
+            def h(x):
+                return g(f(x))
+
+            y = forward_laplacian(h, 0)(x)
+            self.assertEqual(y.x.shape, x.shape)
+            self.assertTrue(np.allclose(y.x, g(f(x))))
+            self.assertTrue(np.allclose(y.jacobian.dense_array, jacobian(h, x).T))
+            self.assertTrue(np.allclose(y.laplacian, laplacian(h, x)))

--- a/test/test_customjvp.py
+++ b/test/test_customjvp.py
@@ -1,33 +1,13 @@
-import unittest
-
 import jax
-import jax.experimental
-import jax.flatten_util as jfu
 import jax.numpy as jnp
 import numpy as np
 
 from folx import forward_laplacian
 
-jax.config.update('jax_enable_x64', True)
+from laplacian_testcase import LaplacianTestCase
 
 
-def jacobian(f, x):
-    return jax.jit(jax.jacobian(f))(x)
-
-
-def laplacian(f, x):
-    flat_x, unravel = jfu.ravel_pytree(x)
-
-    def flat_f(flat_x):
-        return jfu.ravel_pytree(f(unravel(flat_x)))[0]
-
-    def lapl_fn(x):
-        return jnp.trace(jax.hessian(flat_f)(x), axis1=-2, axis2=-1)
-
-    return jax.jit(lapl_fn)(flat_x)
-
-
-class TestForwardLaplacianJvp(unittest.TestCase):
+class TestForwardLaplacianJvp(LaplacianTestCase):
     def test_customjvp(self):
         @jax.custom_jvp
         def fn(x):
@@ -43,6 +23,6 @@ class TestForwardLaplacianJvp(unittest.TestCase):
         x = np.random.randn(10)
         y = forward_laplacian(fn, 0)(x)
         self.assertEqual(y.x.shape, x.shape)
-        self.assertTrue(np.allclose(y.x, fn(x)))
-        self.assertTrue(np.allclose(y.jacobian.dense_array, jacobian(fn, x).T))
-        self.assertTrue(np.allclose(y.laplacian, laplacian(fn, x)))
+        self.assert_allclose(y.x, fn(x))
+        self.assert_allclose(y.jacobian.dense_array, self.jacobian(fn, x).T)
+        self.assert_allclose(y.laplacian, self.laplacian(fn, x))

--- a/test/test_layers.py
+++ b/test/test_layers.py
@@ -145,7 +145,7 @@ class TestForwardLaplacian(unittest.TestCase):
         x = np.random.normal(size=(16,))
 
         def f(x, dtype):
-            return jnp.astype(x, dtype)
+            return jax.lax.convert_element_type(x, dtype)
 
         for dtype in [
             jnp.float16,


### PR DESCRIPTION
This also fixes dtype conversion and adds a test for that. Exceptions will now also start with the original source code line.
