### PR TITLE
shard_map compatibility

### DIFF
--- a/folx/ad.py
+++ b/folx/ad.py
@@ -74,9 +74,7 @@ def jacrev(f):
         eye = jnp.eye(out.size, dtype=out.dtype)
         if hasattr(jax.lax, 'pvary'):
             eye = jax.lax.pvary(eye, tuple(jax.typeof(out).vma))
-        result = jax.vmap(vjp(flat_f, flat_primals))(
-            eye
-        )[0]
+        result = jax.vmap(vjp(flat_f, flat_primals))(eye)[0]
         result = jax.vmap(unravel, out_axes=0)(result)
         if len(primals) == 1:
             return result[0]

--- a/folx/ad.py
+++ b/folx/ad.py
@@ -71,8 +71,10 @@ def jacrev(f):
 
         out = flat_f(flat_primals)
 
+        eye = jnp.eye(out.size, dtype=out.dtype)
+        eye = jax.lax.pvary(eye, tuple(jax.typeof(out).vma))
         result = jax.vmap(vjp(flat_f, flat_primals))(
-            jnp.eye(out.size, dtype=out.dtype)
+            eye
         )[0]
         result = jax.vmap(unravel, out_axes=0)(result)
         if len(primals) == 1:

--- a/folx/ad.py
+++ b/folx/ad.py
@@ -72,7 +72,8 @@ def jacrev(f):
         out = flat_f(flat_primals)
 
         eye = jnp.eye(out.size, dtype=out.dtype)
-        eye = jax.lax.pvary(eye, tuple(jax.typeof(out).vma))
+        if hasattr(jax.lax, 'pvary'):
+            eye = jax.lax.pvary(eye, tuple(jax.typeof(out).vma))
         result = jax.vmap(vjp(flat_f, flat_primals))(
             eye
         )[0]

--- a/folx/api.py
+++ b/folx/api.py
@@ -131,7 +131,9 @@ class FwdJacobian(NamedTuple):
 
         if isinstance(outputs, np.ndarray):
             with jax.ensure_compile_time_eval():
-                result = np.asarray(get_indices(flat_mask, flat_outputs), dtype=int).T
+                # see https://github.com/jax-ml/jax/discussions/31461
+                with jax.sharding.use_abstract_mesh(jax.sharding.AbstractMesh((), ())):
+                    result = np.asarray(get_indices(flat_mask, flat_outputs), dtype=int).T
         else:
             result = get_indices(flat_mask, flat_outputs).T
         return result.reshape(mask.shape)

--- a/folx/api.py
+++ b/folx/api.py
@@ -131,12 +131,18 @@ class FwdJacobian(NamedTuple):
 
         if isinstance(outputs, np.ndarray):
             with jax.ensure_compile_time_eval():
-                if hasattr(jax.sharding, 'use_abstract_mesh'): # jax>=0.7.2
+                if hasattr(jax.sharding, 'use_abstract_mesh'):  # jax>=0.7.2
                     # see https://github.com/jax-ml/jax/discussions/31461
-                    with jax.sharding.use_abstract_mesh(jax.sharding.AbstractMesh((), ())):
-                        result = np.asarray(get_indices(flat_mask, flat_outputs), dtype=int).T
+                    with jax.sharding.use_abstract_mesh(
+                        jax.sharding.AbstractMesh((), ())
+                    ):
+                        result = np.asarray(
+                            get_indices(flat_mask, flat_outputs), dtype=int
+                        ).T
                 else:
-                    result = np.asarray(get_indices(flat_mask, flat_outputs), dtype=int).T
+                    result = np.asarray(
+                        get_indices(flat_mask, flat_outputs), dtype=int
+                    ).T
         else:
             result = get_indices(flat_mask, flat_outputs).T
         return result.reshape(mask.shape)

--- a/folx/api.py
+++ b/folx/api.py
@@ -131,8 +131,11 @@ class FwdJacobian(NamedTuple):
 
         if isinstance(outputs, np.ndarray):
             with jax.ensure_compile_time_eval():
-                # see https://github.com/jax-ml/jax/discussions/31461
-                with jax.sharding.use_abstract_mesh(jax.sharding.AbstractMesh((), ())):
+                if hasattr(jax.sharding, 'use_abstract_mesh'): # jax>=0.7.2
+                    # see https://github.com/jax-ml/jax/discussions/31461
+                    with jax.sharding.use_abstract_mesh(jax.sharding.AbstractMesh((), ())):
+                        result = np.asarray(get_indices(flat_mask, flat_outputs), dtype=int).T
+                else:
                     result = np.asarray(get_indices(flat_mask, flat_outputs), dtype=int).T
         else:
             result = get_indices(flat_mask, flat_outputs).T

--- a/folx/wrapped_functions.py
+++ b/folx/wrapped_functions.py
@@ -228,7 +228,9 @@ def slogdet_jvp(primals, tangents):
         else:
             sign_jvp = jnp.zeros((), dtype=jac_dot_tangent.dtype)
             if hasattr(jax.lax, 'pvary'):
-                sign_jvp = jax.lax.pvary(sign_jvp, tuple(jax.typeof(jac_dot_tangent).vma))
+                sign_jvp = jax.lax.pvary(
+                    sign_jvp, tuple(jax.typeof(jac_dot_tangent).vma)
+                )
             log_det_jvp = jac_dot_tangent
         return (sign_jvp, log_det_jvp)
 

--- a/folx/wrapped_functions.py
+++ b/folx/wrapped_functions.py
@@ -227,7 +227,8 @@ def slogdet_jvp(primals, tangents):
             log_det_jvp = jac_dot_tangent.real
         else:
             sign_jvp = jnp.zeros((), dtype=jac_dot_tangent.dtype)
-            sign_jvp = jax.lax.pvary(sign_jvp, tuple(jax.typeof(jac_dot_tangent).vma))
+            if hasattr(jax.lax, 'pvary'):
+                sign_jvp = jax.lax.pvary(sign_jvp, tuple(jax.typeof(jac_dot_tangent).vma))
             log_det_jvp = jac_dot_tangent
         return (sign_jvp, log_det_jvp)
 

--- a/folx/wrapped_functions.py
+++ b/folx/wrapped_functions.py
@@ -227,6 +227,7 @@ def slogdet_jvp(primals, tangents):
             log_det_jvp = jac_dot_tangent.real
         else:
             sign_jvp = jnp.zeros((), dtype=jac_dot_tangent.dtype)
+            sign_jvp = jax.lax.pvary(sign_jvp, tuple(jax.typeof(jac_dot_tangent).vma))
             log_det_jvp = jac_dot_tangent
         return (sign_jvp, log_det_jvp)
 

--- a/test/test_layers.py
+++ b/test/test_layers.py
@@ -212,7 +212,7 @@ class TestForwardLaplacian(LaplacianTestCase):
                         with jax.set_mesh(mesh):
                             x_sh = jax.sharding.reshard(x[None], jax.P('i'))
                             w_sh = jax.sharding.reshard(w, jax.P())
-                            sign_y_sh, log_y_sh = jax.tree.map(
+                            sign_y, log_y = jax.tree.map(
                                 lambda x: x[0], forward_laplacian_sh(w_sh, x_sh)
                             )
                     else:
@@ -234,6 +234,8 @@ class TestForwardLaplacian(LaplacianTestCase):
                         self.assert_allclose(sign_y.laplacian, self.laplacian(f, x)[0])
                     else:
                         self.assertIsInstance(sign_y, jax.Array)
+                    del sign_y
+                    del log_y
 
     def test_custom_hessian(self):
         x = np.random.normal(size=(16,))


### PR DESCRIPTION
We are using folx to compute the laplacian in batches using a function similar to `folx.batched_vmap`, 
Our samples are sharded along the batch axis, and thus we need to run the `batched_vmap inside` of `shard_map`, so that each jax device only loops over batches of its own samples.

Inside of the `shard_map` the samples are varying, but some of the arrays of folx created from thin air (jnp.eye, jnp.ones, jnp,zeros, etc) are not, causing jax to error (see below).

This PR adds a few `jax.lax.pvary`'s statement, setting the varying mesh axes correctly to make this work.

Example:

```python
import jax
import jax.numpy as jnp
from functools import partial
from jax.sharding import *
from jax import shard_map, P
import numpy as np

import folx

if jax.config.jax_num_cpu_devices <=1:
    jax.config.update("jax_num_cpu_devices", 4)
    
mesh = jax.make_mesh((4,),("i",), axis_types=(AxisType.Explicit,),)
jax.sharding.set_mesh(mesh)

x = np.random.normal(size=(1024, 16 * 16))
w = np.random.normal(size=(16 * 16, 16 * 16))

x_sh = reshard(x, P('i'))
w_sh = reshard(w, P())

sparsity = 0
# sparsity = 0.5 # requires jax>=0.7.2

def f(w, x):
    return jnp.linalg.slogdet(jnp.tanh((x @ w).reshape(16, 16)))

@jax.jit
@partial(jax.shard_map, in_specs=(P(), P('i')), out_specs=P('i'))
@partial(folx.batched_vmap, in_axes=(None, 0), max_batch_size=64)
def forward_laplacian_sh(w, x):
    return folx.forward_laplacian(partial(f, w), sparsity)(x)

forward_laplacian_sh(w_sh, x_sh)
```
Before this PR this errored with 
```
ValueError: unexpected JAX type (e.g. shape/dtype) for argument to vjp function: got float32[1], but expected float32[1]{i} because the corresponding output of the function flat_f had JAX type float32[1]{i}
```

---
In this PR I only set the vma in places I was able to trigger the error with the test, but It might be necessary elsewhere too (e.g. ed77b3a0a2deae690718e98a1ccd2a04905df306 and e580d59353606e34c2557a4f0e88f2c7e516c6aa are a few places)

One nontrivial one is this https://github.com/microsoft/folx/blob/30b053a38c0731c6b41a0e61a4c51bc773a2fcd9/folx/ad.py#L92-L96
which would need a `pvary` setting the vma of `eye` if one ever tried to `linear_transpose` the function, see my comment here https://github.com/netket/netket/pull/2072#discussion_r2231095176 .