### PR TITLE
Handle the new JAX bind-params API

### DIFF
--- a/folx/ad.py
+++ b/folx/ad.py
@@ -94,6 +94,7 @@ def jacfwd(f):
             return jax.jvp(f, primals, unravel(s))[1]
 
         eye = jnp.eye(flat_primals.size, dtype=flat_primals.dtype)
+        eye = jax.lax.pvary(eye, tuple(jax.typeof(flat_primals).vma))
         J = jax.vmap(jvp_fun, out_axes=-1)(eye)
         return J
 

--- a/folx/interpreter.py
+++ b/folx/interpreter.py
@@ -1,5 +1,6 @@
 import functools
 import logging
+import re
 import warnings
 from collections import defaultdict
 from typing import TYPE_CHECKING, Callable, ParamSpec, Sequence, TypeVar
@@ -42,6 +43,36 @@ from .wrapped_functions import get_laplacian, wrap_forward_laplacian
 
 R = TypeVar('R', bound=PyTree[Array])
 P = ParamSpec('P')
+
+
+def _version_key(version: str) -> tuple[int, ...]:
+    return tuple(
+        int(match.group(0))
+        for part in version.split('.')
+        if (match := re.match(r'\d+', part)) is not None
+    )
+
+
+_USES_DICT_BIND_PARAMS = _version_key(jax.__version__) >= (0, 9, 2)
+
+
+def _split_bind_params(primitive, params):
+    """Normalize JAX primitive bind params across old and new JAX APIs."""
+
+    bind_params = primitive.get_bind_params(params)
+    if _USES_DICT_BIND_PARAMS:
+        if not isinstance(bind_params, dict):
+            raise TypeError(
+                'Expected primitive.get_bind_params() to return a dict for '
+                f'JAX >= 0.9.2, got {bind_params!r}.'
+            )
+        return (), bind_params
+    if not isinstance(bind_params, tuple) or len(bind_params) != 2:
+        raise TypeError(
+            'Expected primitive.get_bind_params() to return a 2-tuple for '
+            f'JAX < 0.9.2, got {bind_params!r}.'
+        )
+    return bind_params
 
 
 class JaxExprEnvironment:
@@ -169,7 +200,7 @@ def eval_jaxpr_with_forward_laplacian(
         )
 
     def eval_custom_jvp(eqn: JaxprEqn, invals):
-        subfuns, args = eqn.primitive.get_bind_params(eqn.params)
+        subfuns, args = _split_bind_params(eqn.primitive, eqn.params)
         fn = functools.partial(eqn.primitive.bind, *subfuns, **args)
         with LoggingPrefix(f'({summarize(eqn.source_info)})'):
             return wrap_forward_laplacian(fn)(
@@ -177,7 +208,7 @@ def eval_jaxpr_with_forward_laplacian(
             )
 
     def eval_laplacian(eqn: JaxprEqn, invals):
-        subfuns, params = eqn.primitive.get_bind_params(eqn.params)
+        subfuns, params = _split_bind_params(eqn.primitive, eqn.params)
         with LoggingPrefix(f'({summarize(eqn.source_info)})'):
             fn = get_laplacian(eqn.primitive, True)
             return fn(
@@ -189,7 +220,7 @@ def eval_jaxpr_with_forward_laplacian(
         # Eval expression
         try:
             if all(not isinstance(x, FwdLaplArray) for x in invals):
-                subfuns, bind_params = eqn.primitive.get_bind_params(eqn.params)
+                subfuns, bind_params = _split_bind_params(eqn.primitive, eqn.params)
                 # If non of the inputs were dependent on an FwdLaplArray,
                 # we can just use the regular primitive. This will avoid
                 # omnistaging. While this could cost us some memory and speed,

--- a/test/test_interpreter.py
+++ b/test/test_interpreter.py
@@ -1,0 +1,48 @@
+import pytest
+
+import folx.interpreter as interpreter_mod
+
+
+class _DummyPrimitive:
+    def __init__(self, result):
+        self.result = result
+
+    def get_bind_params(self, params):
+        assert params == {'x': 1}
+        return self.result
+
+
+def test_split_bind_params_accepts_legacy_tuple(monkeypatch):
+    monkeypatch.setattr(interpreter_mod, '_USES_DICT_BIND_PARAMS', False)
+    subfuns, params = interpreter_mod._split_bind_params(
+        _DummyPrimitive((['fn'], {'x': 2})), {'x': 1}
+    )
+    assert subfuns == ['fn']
+    assert params == {'x': 2}
+
+
+def test_split_bind_params_accepts_new_dict_only_api(monkeypatch):
+    monkeypatch.setattr(interpreter_mod, '_USES_DICT_BIND_PARAMS', True)
+    subfuns, params = interpreter_mod._split_bind_params(
+        _DummyPrimitive({'x': 2}), {'x': 1}
+    )
+    assert subfuns == ()
+    assert params == {'x': 2}
+
+
+def test_split_bind_params_rejects_invalid_tuple_shape(monkeypatch):
+    monkeypatch.setattr(interpreter_mod, '_USES_DICT_BIND_PARAMS', False)
+    with pytest.raises(TypeError, match='2-tuple'):
+        interpreter_mod._split_bind_params(_DummyPrimitive(({'x': 2},)), {'x': 1})
+
+
+def test_split_bind_params_rejects_dict_on_legacy_jax(monkeypatch):
+    monkeypatch.setattr(interpreter_mod, '_USES_DICT_BIND_PARAMS', False)
+    with pytest.raises(TypeError, match='JAX < 0.9.2'):
+        interpreter_mod._split_bind_params(_DummyPrimitive({'x': 2}), {'x': 1})
+
+
+def test_split_bind_params_rejects_tuple_on_new_jax(monkeypatch):
+    monkeypatch.setattr(interpreter_mod, '_USES_DICT_BIND_PARAMS', True)
+    with pytest.raises(TypeError, match='JAX >= 0.9.2'):
+        interpreter_mod._split_bind_params(_DummyPrimitive((['fn'], {'x': 2})), {'x': 1})

--- a/test/test_shard_map.py
+++ b/test/test_shard_map.py
@@ -1,0 +1,24 @@
+from functools import partial
+
+import jax
+import jax.numpy as jnp
+
+from folx import forward_laplacian
+
+
+def test_shard_map_bug_integer_pow():
+    # see https://github.com/microsoft/folx/issues/38
+
+    def f(w, x):
+        return jax.lax.integer_pow(x @ w, 1)
+
+    @jax.smap(out_axes=0, in_axes=(None, 0), axis_name='i')
+    @partial(jax.vmap, in_axes=(None, 0))
+    def test(w, x):
+        return forward_laplacian(partial(f, w))(x)
+
+    x = jnp.ones((1, 16))
+    w = jnp.ones((16, 16))
+
+    with jax.set_mesh(jax.sharding.Mesh(jax.devices(), 'i')):
+        test(w, x)


### PR DESCRIPTION
## Summary
- normalize `primitive.get_bind_params(...)` in the interpreter
- gate the compatibility behavior on `jax >= 0.9.2`
- add regression tests covering both the legacy tuple-return API and the new dict-return API

## Root cause
For newer JAX versions, some primitives such as `integer_pow`, `lt`, and `jit` return a plain dict from `primitive.get_bind_params(...)` instead of `(subfuns, params)`. `folx` still unpacked the result unconditionally, which caused failures like `ValueError: not enough values to unpack`.

## Validation
- `uv run --no-dev --with pytest --with pytest-xdist pytest test/test_interpreter.py test/test_customjvp.py test/test_operator.py`
- `uv run --python 3.13 --no-dev --with pytest --with pytest-xdist --with jax==0.9.2 --with jaxlib==0.9.2 pytest test/test_interpreter.py test/test_customjvp.py test/test_operator.py`

Both runs passed locally.
